### PR TITLE
Enhancement/hide the add user to server button if powerlevel < 50

### DIFF
--- a/app/components/ChannelBar.tsx
+++ b/app/components/ChannelBar.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { routes } from "../constants/routes";
 import { selectChannels } from "../reducers/channels";
 import * as uuid from "uuid";
+import { selectPermissions } from "../reducers/permissions";
 
 export function ChannelBar(props: { server: IServer }): JSX.Element {
     const history = useHistory();
@@ -15,6 +16,11 @@ export function ChannelBar(props: { server: IServer }): JSX.Element {
 
     const serverChannels = _channels[props.server.serverID];
     const channelIDs = Object.keys(serverChannels || {});
+
+    const permissions = useSelector(selectPermissions);
+    const serverPermission = permissions[props.server.serverID]
+
+    console.log(serverPermission);
 
     return (
         <div className="sidebar">
@@ -32,12 +38,15 @@ export function ChannelBar(props: { server: IServer }): JSX.Element {
                             "/add-user"
                         }
                     >
-                        <span className="add-user-icon">
+                        {serverPermission?.powerLevel > 50 && (
+                            <span className="add-user-icon">
                             <FontAwesomeIcon
                                 className="has-text-dark"
                                 icon={faUserPlus}
                             />
                         </span>
+                        )}
+
                     </Link>
                 </h1>
             </div>


### PR DESCRIPTION
They won't be able to add a user due to lack of permission anyway, so this should be hidden if you don't have the required permission.